### PR TITLE
fix(ci): remove release_npm step override that broke workflow parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: 24.x
           package-manager-cache: "false"
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -123,7 +123,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: .repo
-        run: cd .repo && yarn install --check-files --frozen-lockfile --ignore-engines
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -363,16 +363,11 @@ releaseWorkflow.file!.addOverride('jobs.release.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release.permissions.contents', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_npm.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_npm.permissions.contents', 'write');
-releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.node-version', '24');
-releaseWorkflow.file!.addOverride('jobs.release_npm.steps.4.run', 'cd .repo && yarn install --check-files --frozen-lockfile --ignore-engines');
 releaseWorkflow.file!.addOverride('jobs.release_pypi.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_pypi.permissions.contents', 'write');
-releaseWorkflow.file!.addOverride('jobs.release_pypi.steps.0.with.node-version', workflowNodeVersion);
 releaseWorkflow.file!.addOverride('jobs.release_nuget.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_nuget.permissions.contents', 'write');
-releaseWorkflow.file!.addOverride('jobs.release_nuget.steps.0.with.node-version', workflowNodeVersion);
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.contents', 'write');
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.0.with.node-version', workflowNodeVersion);
 
 project.synth();


### PR DESCRIPTION
The release run for main (post #247) failed with zero jobs — a workflow-file parse error.

Root cause: `.projenrc.ts` overrode `jobs.release_npm.steps.4.run` to add `--ignore-engines`, but step 4 is now the Checkout step (the Aikido Safe-Chain step shifted indices), so the generated step had both `uses:` and `run:`, which GitHub Actions rejects at parse time.

Fix:
- Drop the `steps.4.run` override — the `--ignore-engines` band-aid is obsolete now that workflows run node 24.x (the engine check passes).
- Drop the per-job `node-version` overrides — `workflowNodeVersion` renders `24.x` into every job natively.
- Keep the id-token/contents permissions overrides (needed for trusted publishing).

Verified: regenerated `release.yml` has no `uses`+`run` steps and all six setup-node steps are `24.x`.