### PR TITLE
fix(ci): publish Go module with the workflow's own token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,5 +279,5 @@ jobs:
         env:
           GIT_USER_NAME: github-actions[bot]
           GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx -p publib@latest publib-golang

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -65,6 +65,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
   publishToGo: {
     moduleName: 'github.com/jaysonrawlins/cdk-iam-policy-builder-helper',
     packageName: 'cdkiampolicybuilderhelper',
+    // The Go module is published into this same repo, so the workflow's own
+    // token suffices — no PAT (long-lived tokens eliminated in eb4ba25).
+    githubTokenSecret: 'GITHUB_TOKEN',
   },
 
   githubOptions: {


### PR DESCRIPTION
Release run on main now gets through install and published npm/PyPI/NuGet, but `release_golang` fails: `GITHUB_TOKEN env variable is required` -- it references `secrets.GO_GITHUB_TOKEN`, which doesn't exist (long-lived tokens were eliminated in `eb4ba25`; the pre-projen workflow minted a GitHub App token in-job instead).

The Go module is published into this same repo (`cdkiampolicybuilderhelper/` on main), so no cross-repo credential is needed: set `publishToGo.githubTokenSecret: 'GITHUB_TOKEN'` and the job's existing `contents: write` permission covers the push. Built-in-token pushes also can't retrigger workflows, so no release-loop risk (the old App token relied on the latest-commit guard for that).

No new secrets, no overrides -- one supported projen option.