### PR TITLE
fix(ci): un-ignore Go module dir and fix publib push auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,5 +279,5 @@ jobs:
         env:
           GIT_USER_NAME: github-actions[bot]
           GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: x-access-token:${{ secrets.GITHUB_TOKEN }}
         run: npx -p publib@latest publib-golang

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 methods_list.txt
-cdkiampolicybuilderhelper/
 .dccache
 .yalc
 /test-reports/

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -100,7 +100,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
 
   gitignore: [
     'methods_list.txt',
-    'cdkiampolicybuilderhelper/',
+    // Never ignore cdkiampolicybuilderhelper/ — the published Go module lives
+    // there on main; publib's release commit is `git rm` + copy + `git add .`,
+    // so ignoring it makes the add silently skip the copy and the release
+    // commit deletes the module.
     '.dccache',
     '.yalc',
   ],
@@ -372,5 +375,13 @@ releaseWorkflow.file!.addOverride('jobs.release_nuget.permissions.id-token', 'wr
 releaseWorkflow.file!.addOverride('jobs.release_nuget.permissions.contents', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.contents', 'write');
+// publib pushes via `https://<GITHUB_TOKEN>@github.com`; the workflow's own
+// token is an installation token, which git only accepts in the documented
+// `x-access-token:<token>` userinfo form (bare, it dies with "could not read
+// Password"). projen can only render `${{ secrets.X }}` here, so prefix the
+// value ourselves. Step 11 is the publib-golang Release step; if steps shift,
+// this lands as a harmless extra env on the wrong step and the publish fails
+// loudly on the missing-token error — it cannot corrupt the workflow.
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11.env.GITHUB_TOKEN', 'x-access-token:${{ secrets.GITHUB_TOKEN }}');
 
 project.synth();


### PR DESCRIPTION
Two bugs behind the `release_golang` failure, both reproduced locally with `PUBLIB_DRYRUN=true publib-golang` against a fresh clone:

**1. `.gitignore` was set to ignore `cdkiampolicybuilderhelper/` -- the published Go module (dangerous)**
publib releases by `git rm -r <module>` → copy fresh module in → `git add .` → commit → push. With the module dir gitignored (added in the projen resurrection), `git add .` silently skips the fresh copy, producing a **deletion-only commit** (`5 files changed, 294 deletions`) that would have wiped the Go module from main. The auth failure below is the only reason it never landed. Verified: replaying the sequence with the fixed `.gitignore` stages the module as modifications, as expected.

**2. Built-in token can't push in publib's URL format**
publib pushes via `https://<GITHUB_TOKEN env>@github.com`. The workflow's `GITHUB_TOKEN` is an installation token, which git only accepts in the documented `x-access-token:<token>` userinfo form -- bare, git fails with `could not read Password for 'https://***@github.com'`. projen can only render `${{ secrets.X }}` for this env, so the override prefixes the value: `x-access-token:${{ secrets.GITHUB_TOKEN }}`. The override is index-based but fail-safe: if steps ever shift it becomes an unused env on a neighboring step and the publish fails loudly on the missing token -- it cannot produce invalid YAML (unlike the `steps.4.run` override removed in #259).

Still no PATs / long-lived credentials -- the job's own token with its existing `contents: write` permission does the push.

Verification once merged: the release run's `release_golang` job should push a `chore(release): vX.Y.Z` commit to main containing modifications (not deletions) under `cdkiampolicybuilderhelper/`, plus the `cdkiampolicybuilderhelper/vX.Y.Z` tag.