### PR TITLE
fix(ci): publish Go module to dedicated 'go' branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
+          GIT_BRANCH: go
           GIT_USER_NAME: github-actions[bot]
           GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: x-access-token:${{ secrets.GITHUB_TOKEN }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -68,6 +68,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
     // The Go module is published into this same repo, so the workflow's own
     // token suffices — no PAT (long-lived tokens eliminated in eb4ba25).
     githubTokenSecret: 'GITHUB_TOKEN',
+    // Publish to a dedicated branch, not main: go resolution works off the
+    // cdkiampolicybuilderhelper/vX.Y.Z tags, and main's required build check
+    // (require-build-green ruleset) would reject publib's direct push.
+    gitBranch: 'go',
   },
 
   githubOptions: {


### PR DESCRIPTION
Companion to the new merge-gating setup (settings changed outside this PR: `allow_auto_merge: true` + repo ruleset `require-build-green` making the `build` check required on main).

Ruleset required checks gate **all ref updates** to main -- including `release_golang`'s direct push of the go release commit, which carries no checks and would be rejected. Rather than a `github-actions` bypass (same actor automerge uses -- would reopen the merge-without-green hole), publish the Go module to a dedicated `go` branch via `publishToGo.gitBranch`. Go resolution works off the `cdkiampolicybuilderhelper/vX.Y.Z` tags, which are unaffected by branch rulesets.

With this in place the Dependabot loop is finally what it was believed to be: PR opens → automerge arms native auto-merge → blocked builds (Safe-Chain package age) wait → Monday's dependabot-unblocker reruns them → packages age past 168h → build greens → merges green.

Follow-up (separate): `cdkiampolicybuilderhelper/` on main goes stale as of v0.1.1 and can be removed once the `go` branch has its first release.